### PR TITLE
feat: also display printable unicode notation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import nox
 
-PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
+PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 SOURCE_DIRECTORY = Path("ski_lint").resolve()
 TEST_DIRECTORY = Path("tests").resolve()

--- a/ski_lint/cli.py
+++ b/ski_lint/cli.py
@@ -43,15 +43,16 @@ def run(*filenames: str, check: bool = False, context_width: int) -> int:
                 for char, char_positions in line_result.chars.items():
                     for char_pos in char_positions:
                         context = extract_context(line_result.line, char_pos, context_width)
+                        unicode_notation = f"U+{ord(char):0X}"
 
                         error_msg = f"{filename} ({encoding}), "
                         error_msg += f"line {line_result.line_num}, "
                         error_msg += f"pos {char_pos}, "
                         if not char.isprintable():
-                            error_msg += f"non-printable char U+{ord(char):0x}, "
-                            context = context.replace(char, f"U+{ord(char):0x}")
+                            error_msg += f"non-printable char {unicode_notation}, "
+                            context = context.replace(char, unicode_notation)
                         else:
-                            error_msg += f"char '{char}', "
+                            error_msg += f"char {unicode_notation} '{char}', "
                         error_msg += f"context: '{context}'"
 
                         log.error(error_msg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,11 +21,11 @@ def test_files_output_good(caplog, test_files_good):
 
 def test_files_output_bad(caplog, test_files_bad):
     exp = [
-        "tests/files/bad/special.txt (Windows-1252), line 1, pos 9, char '…', context: 'Hi there…'",
-        "tests/files/bad/umlaut.txt (utf-8), line 1, pos 349, char 'ä', context: 'y next level pitchfork käle chips leggings gastrop'",
-        "tests/files/bad/umlaut.txt (utf-8), line 1, pos 547, char 'ö', context: 'gs. Waistcoat jianbing föur dollar toast jean shor'",
-        "tests/files/bad/umlaut.txt (utf-8), line 3, pos 190, char 'Å', context: 'eitan viral photo booth Åir plant cliche neutra la'",
-        "tests/files/bad/zero-width-space.txt (Windows-1252), line 1, pos 62, non-printable char U+200b, context: 'ace (\\u200b) at the end!U+200b'",
+        "tests/files/bad/special.txt (Windows-1252), line 1, pos 9, char U+2026 '…', context: 'Hi there…'",
+        "tests/files/bad/umlaut.txt (utf-8), line 1, pos 349, char U+E4 'ä', context: 'y next level pitchfork käle chips leggings gastrop'",
+        "tests/files/bad/umlaut.txt (utf-8), line 1, pos 547, char U+F6 'ö', context: 'gs. Waistcoat jianbing föur dollar toast jean shor'",
+        "tests/files/bad/umlaut.txt (utf-8), line 3, pos 190, char U+C5 'Å', context: 'eitan viral photo booth Åir plant cliche neutra la'",
+        "tests/files/bad/zero-width-space.txt (Windows-1252), line 1, pos 62, non-printable char U+200B, context: 'ace (\\u200b) at the end!U+200B'",
     ]
     run(*test_files_bad, context_width=50)
     assert all([e in caplog.text for e in exp])


### PR DESCRIPTION
Sometimes it is also handy if the unicode is printed for printable chars, if you want to look it up for more info. E.g. hyphen like unicode chars all look alike, but often have very different unicode codes.

Also added Python 3.13 to nox file.